### PR TITLE
feature: jpql 쿼리 인기게시물 조회, querydsl 검색기능 구현

### DIFF
--- a/src/main/java/com/matching/participate/domain/Participate.java
+++ b/src/main/java/com/matching/participate/domain/Participate.java
@@ -21,7 +21,7 @@ public class Participate {
     @JoinColumn(name = "user_id")
     private Member participate;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/com/matching/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/matching/photo/repository/PhotoRepository.java
@@ -3,5 +3,9 @@ package com.matching.photo.repository;
 import com.matching.photo.domain.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    Optional<List<Photo>> findAllByPost_Id(Long postId);
 }

--- a/src/main/java/com/matching/post/controller/PostController.java
+++ b/src/main/java/com/matching/post/controller/PostController.java
@@ -55,17 +55,18 @@ public class PostController {
 
     @GetMapping("/categoryList")
     public ResponseDto getPostByCategoryId(
-            @RequestBody PostCategoryRequest request
-            ) {
+        @RequestBody PostCategoryRequest request
+    ) {
         return ResponseUtil.SUCCESS("조회성공", postService.getPostByCategoryDesc(request.getCategoryId()));
     }
 
     @DeleteMapping("/{postId}")
-    public ResponseEntity<?> deletePost(
+    public ResponseDto deletePost(
         @PathVariable Long postId,
         @AuthenticationPrincipal User user
     ) {
-        return null;
+        postService.deletePost(postId, Long.parseLong(user.getUsername()));
+        return ResponseUtil.SUCCESS("삭제성공", true);
     }
 
 }

--- a/src/main/java/com/matching/post/controller/PostController.java
+++ b/src/main/java/com/matching/post/controller/PostController.java
@@ -38,7 +38,6 @@ public class PostController {
             @PathVariable Long postId
     ) {
         PostResponse postResponse = postService.getPost(postId);
-
         return ResponseUtil.SUCCESS("글 조회 성공", postResponse);
     }
 

--- a/src/main/java/com/matching/post/controller/PostController.java
+++ b/src/main/java/com/matching/post/controller/PostController.java
@@ -2,10 +2,7 @@ package com.matching.post.controller;
 
 import com.matching.common.dto.ResponseDto;
 import com.matching.common.utils.ResponseUtil;
-import com.matching.post.dto.PostCategoryRequest;
-import com.matching.post.dto.PostRequest;
-import com.matching.post.dto.PostResponse;
-import com.matching.post.dto.PostUpdateRequest;
+import com.matching.post.dto.*;
 import com.matching.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +11,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -69,4 +67,11 @@ public class PostController {
         return ResponseUtil.SUCCESS("삭제성공", true);
     }
 
+
+    @GetMapping("/search")
+    public ResponseDto getPostSearchList(
+            @RequestBody @Valid PostSearchRequest parameter
+    ) {
+        return ResponseUtil.SUCCESS("조회성공", postService.getPostSearchList(parameter));
+    }
 }

--- a/src/main/java/com/matching/post/controller/PostController.java
+++ b/src/main/java/com/matching/post/controller/PostController.java
@@ -52,6 +52,13 @@ public class PostController {
         return ResponseUtil.SUCCESS("글 수정 성공", id);
     }
 
+    @GetMapping("/getListAsc")
+    public ResponseDto getTest() {
+        Long categoryId = 1L;
+
+        return ResponseUtil.SUCCESS("조회성공", postService.getPostByCategoryAsc(categoryId));
+    }
+
     @DeleteMapping("/{postId}")
     public ResponseEntity<?> deletePost(
         @PathVariable Long postId,

--- a/src/main/java/com/matching/post/controller/PostController.java
+++ b/src/main/java/com/matching/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.matching.post.controller;
 
 import com.matching.common.dto.ResponseDto;
 import com.matching.common.utils.ResponseUtil;
+import com.matching.post.dto.PostCategoryRequest;
 import com.matching.post.dto.PostRequest;
 import com.matching.post.dto.PostResponse;
 import com.matching.post.dto.PostUpdateRequest;
@@ -52,11 +53,11 @@ public class PostController {
         return ResponseUtil.SUCCESS("글 수정 성공", id);
     }
 
-    @GetMapping("/getListAsc")
-    public ResponseDto getTest() {
-        Long categoryId = 1L;
-
-        return ResponseUtil.SUCCESS("조회성공", postService.getPostByCategoryAsc(categoryId));
+    @GetMapping("/categoryList")
+    public ResponseDto getPostByCategoryId(
+            @RequestBody PostCategoryRequest request
+            ) {
+        return ResponseUtil.SUCCESS("조회성공", postService.getPostByCategoryDesc(request.getCategoryId()));
     }
 
     @DeleteMapping("/{postId}")

--- a/src/main/java/com/matching/post/domain/Post.java
+++ b/src/main/java/com/matching/post/domain/Post.java
@@ -1,7 +1,9 @@
 package com.matching.post.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.matching.common.domain.BaseEntity;
 import com.matching.member.domain.Member;
+import com.matching.participate.domain.Participate;
 import com.matching.plan.domain.Plan;
 import com.matching.post.dto.PostRequest;
 import com.matching.post.dto.PostUpdateRequest;
@@ -9,6 +11,8 @@ import lombok.*;
 import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -26,19 +30,24 @@ public class Post extends BaseEntity {
     private String title;
     private String content;
 
-
-    @OneToOne(fetch = FetchType.LAZY)
+    //(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
+    @JsonIgnore
     private Plan plan;
 
     // 글 작성자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private Member author;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @JsonIgnore
+    private List<Participate> participateList = new ArrayList<>();
 
     public void update(PostUpdateRequest request) {
         this.title = request.getTitle();

--- a/src/main/java/com/matching/post/domain/Post.java
+++ b/src/main/java/com/matching/post/domain/Post.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.matching.common.domain.BaseEntity;
 import com.matching.member.domain.Member;
 import com.matching.participate.domain.Participate;
+import com.matching.photo.domain.Photo;
 import com.matching.plan.domain.Plan;
 import com.matching.post.dto.PostRequest;
 import com.matching.post.dto.PostUpdateRequest;
 import lombok.*;
 import org.hibernate.envers.AuditOverride;
+import org.springframework.data.jpa.repository.EntityGraph;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -22,6 +24,16 @@ import java.util.List;
 @AuditOverride(forClass = BaseEntity.class)
 @Entity
 @Table(name = "post")
+//@NamedEntityGraph(
+//        name = "Post.photoParticipate",
+//        attributeNodes = {
+//                @NamedAttributeNode("author"),
+//                @NamedAttributeNode("plan"),
+//                @NamedAttributeNode("participateList"),
+//                @NamedAttributeNode(value = "photoList",subgraph = "photoList")
+//        },
+//        subgraphs = @NamedSubgraph(name ="photoList",attributeNodes = {@NamedAttributeNode("photo")})
+//)
 public class Post extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,9 +57,13 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "user_id")
     private Member author;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
     @JsonIgnore
     private List<Participate> participateList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    @JsonIgnore
+    private List<Photo> photoList = new ArrayList<>();
 
     public void update(PostUpdateRequest request) {
         this.title = request.getTitle();

--- a/src/main/java/com/matching/post/domain/Post.java
+++ b/src/main/java/com/matching/post/domain/Post.java
@@ -24,16 +24,6 @@ import java.util.List;
 @AuditOverride(forClass = BaseEntity.class)
 @Entity
 @Table(name = "post")
-//@NamedEntityGraph(
-//        name = "Post.photoParticipate",
-//        attributeNodes = {
-//                @NamedAttributeNode("author"),
-//                @NamedAttributeNode("plan"),
-//                @NamedAttributeNode("participateList"),
-//                @NamedAttributeNode(value = "photoList",subgraph = "photoList")
-//        },
-//        subgraphs = @NamedSubgraph(name ="photoList",attributeNodes = {@NamedAttributeNode("photo")})
-//)
 public class Post extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,12 +32,11 @@ public class Post extends BaseEntity {
     private String title;
     private String content;
 
-    //(fetch = FetchType.LAZY)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "plan_id")
     @JsonIgnore
     private Plan plan;
@@ -57,11 +46,11 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "user_id")
     private Member author;
 
-    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JsonIgnore
     private List<Participate> participateList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JsonIgnore
     private List<Photo> photoList = new ArrayList<>();
 

--- a/src/main/java/com/matching/post/domain/Post.java
+++ b/src/main/java/com/matching/post/domain/Post.java
@@ -45,11 +45,11 @@ public class Post extends BaseEntity {
         this.content = request.getContent();
     }
 
-    public static Post from(PostRequest parameter) {
+    public static Post from(PostRequest parameter, Category category) {
         return Post.builder()
                 .title(parameter.getTitle())
                 .content(parameter.getContent())
-                .category(parameter.getCategory())
+                .category(category)
                 .author(parameter.getMember())
                 .build();
     }

--- a/src/main/java/com/matching/post/domain/PostPhoto.java
+++ b/src/main/java/com/matching/post/domain/PostPhoto.java
@@ -1,0 +1,37 @@
+package com.matching.post.domain;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+
+import com.matching.photo.domain.Photo;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostPhoto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_photo_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "photo_id")
+    private Photo photo;
+}

--- a/src/main/java/com/matching/post/dto/PostCategoryRequest.java
+++ b/src/main/java/com/matching/post/dto/PostCategoryRequest.java
@@ -1,0 +1,10 @@
+package com.matching.post.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostCategoryRequest {
+    private Long categoryId;
+}

--- a/src/main/java/com/matching/post/dto/PostRequest.java
+++ b/src/main/java/com/matching/post/dto/PostRequest.java
@@ -18,7 +18,7 @@ public class PostRequest {
     private String title;
     private String content;
     private Member member;
-    private Category category;
+    private Long categoryId;
 
     /**
      * 목표

--- a/src/main/java/com/matching/post/dto/PostResponse.java
+++ b/src/main/java/com/matching/post/dto/PostResponse.java
@@ -1,7 +1,5 @@
 package com.matching.post.dto;
 
-import com.matching.photo.domain.Photo;
-import com.matching.post.domain.Category;
 import com.matching.post.domain.Post;
 import lombok.*;
 

--- a/src/main/java/com/matching/post/dto/PostResponse.java
+++ b/src/main/java/com/matching/post/dto/PostResponse.java
@@ -1,11 +1,15 @@
 package com.matching.post.dto;
 
+import com.matching.photo.domain.Photo;
 import com.matching.post.domain.Post;
 import lombok.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -25,7 +29,7 @@ public class PostResponse {
 
     private List<String> photoList;
 
-    public static PostResponse from(Post post, List<String> test) {
+    public static PostResponse from(Post post, List<String> photoList) {
         return PostResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -36,7 +40,22 @@ public class PostResponse {
                 .createdAt(post.getCreatedAt())
                 .startedAt(post.getPlan().getStartedAt())
                 .endedAt(post.getPlan().getEndedAt())
-                .photoList(test)
+                .photoList(photoList)
                 .build();
+    }
+
+    public static Page<PostResponse> fromEntitiesPage(Page<Post> postPage) {
+        return new PageImpl<>(
+                postPage.stream()
+                        .map(post -> {
+                            List<String> photoList = post.getPhotoList().stream()
+                                    .map(Photo::getPathname)
+                                    .collect(Collectors.toList());
+                            return PostResponse.from(post, photoList);
+                        })
+                        .collect(Collectors.toList()),
+                postPage.getPageable(),
+                postPage.getTotalElements()
+        );
     }
 }

--- a/src/main/java/com/matching/post/dto/PostResponse.java
+++ b/src/main/java/com/matching/post/dto/PostResponse.java
@@ -1,9 +1,13 @@
 package com.matching.post.dto;
 
+import com.matching.photo.domain.Photo;
+import com.matching.post.domain.Category;
 import com.matching.post.domain.Post;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -11,21 +15,30 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 public class PostResponse {
-
     private Long id;
     private String title;
     private String content;
+    private String categoryName;
+    private String plan;
     private String author;
-
     private LocalDateTime createdAt;
+    private LocalDate startedAt;
+    private LocalDate endedAt;
 
-    public static PostResponse from(Post post) {
+    private List<String> photoList;
+
+    public static PostResponse from(Post post, List<String> test) {
         return PostResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
+                .categoryName(post.getCategory().getCategoryName())
+                .plan(post.getPlan().getDetail())
                 .author(post.getAuthor().getNickname())
                 .createdAt(post.getCreatedAt())
+                .startedAt(post.getPlan().getStartedAt())
+                .endedAt(post.getPlan().getEndedAt())
+                .photoList(test)
                 .build();
     }
 }

--- a/src/main/java/com/matching/post/dto/PostSearchRequest.java
+++ b/src/main/java/com/matching/post/dto/PostSearchRequest.java
@@ -1,0 +1,30 @@
+package com.matching.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.lang.Nullable;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PostSearchRequest {
+    private String keyword;
+    @Nullable
+    private int pageNum;
+    @Nullable
+    private int pageSize;
+
+//    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+//    private LocalDate startDate;
+//    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+//    private LocalDate endDate;
+//
+    public int getPageSize() {
+        return this.pageSize == 0 ? 5 : this.pageSize;
+    }
+
+}

--- a/src/main/java/com/matching/post/repository/PostListParticipateCountRepository.java
+++ b/src/main/java/com/matching/post/repository/PostListParticipateCountRepository.java
@@ -1,4 +1,0 @@
-package com.matching.post.repository;
-
-public class PostListParticipateCountRepository {
-}

--- a/src/main/java/com/matching/post/repository/PostListParticipateCountRepository.java
+++ b/src/main/java/com/matching/post/repository/PostListParticipateCountRepository.java
@@ -1,0 +1,4 @@
+package com.matching.post.repository;
+
+public class PostListParticipateCountRepository {
+}

--- a/src/main/java/com/matching/post/repository/PostRepository.java
+++ b/src/main/java/com/matching/post/repository/PostRepository.java
@@ -1,13 +1,21 @@
 package com.matching.post.repository;
 
 import com.matching.post.domain.Post;
+import com.matching.post.dto.PostResponse;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndAuthor_Id(Long postId, Long userId);
+
+    @Query("SELECT p FROM Post p LEFT JOIN p.participateList pt WHERE p.category.id = :categoryId GROUP BY p ORDER BY COUNT (pt.id) ASC")
+    List<Post> findAllOrderByParticipantCountByCategoryAsc(@Param("categoryId") Long categoryId);
 }
 

--- a/src/main/java/com/matching/post/repository/PostRepository.java
+++ b/src/main/java/com/matching/post/repository/PostRepository.java
@@ -25,5 +25,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     )
     Page<Post> findAllOrderByParticipantByPhotoCountByCategoryDesc(@Param("categoryId") Long categoryId, Pageable pageable);
 
+    // 게시글 제목 별 검색
+
 }
 

--- a/src/main/java/com/matching/post/repository/PostRepository.java
+++ b/src/main/java/com/matching/post/repository/PostRepository.java
@@ -1,32 +1,25 @@
 package com.matching.post.repository;
 
 import com.matching.post.domain.Post;
-import com.matching.post.dto.PostResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import javax.persistence.Subgraph;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndAuthor_Id(Long postId, Long userId);
-
     @Query(value = "select * from post p\n" +
             "    left join participate p2\n" +
             "        on p.post_id = p2.post_id\n" +
             "    left join photo p3\n" +
             "        on p.post_id = p3.post_id\n" +
-            "    where category_id = 1\n" +
-            "    and p2.status = 'LEADER' OR p2.status = 'ADMISSION'\n" +
+            "    where p.category_id = :categoryId\n" +
+            "       and (p2.status = 'LEADER' OR p2.status = 'ADMISSION')\n" +
             "    group by p.post_id\n" +
             "    order by count(p2.id) DESC", nativeQuery = true
     )

--- a/src/main/java/com/matching/post/repository/PostRepository.java
+++ b/src/main/java/com/matching/post/repository/PostRepository.java
@@ -3,19 +3,34 @@ package com.matching.post.repository;
 import com.matching.post.domain.Post;
 import com.matching.post.dto.PostResponse;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.Subgraph;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndAuthor_Id(Long postId, Long userId);
 
-    @Query("SELECT p FROM Post p LEFT JOIN p.participateList pt WHERE p.category.id = :categoryId GROUP BY p ORDER BY COUNT (pt.id) ASC")
-    List<Post> findAllOrderByParticipantCountByCategoryAsc(@Param("categoryId") Long categoryId);
+    @Query(value = "select * from post p\n" +
+            "    left join participate p2\n" +
+            "        on p.post_id = p2.post_id\n" +
+            "    left join photo p3\n" +
+            "        on p.post_id = p3.post_id\n" +
+            "    where category_id = 1\n" +
+            "    and p2.status = 'LEADER' OR p2.status = 'ADMISSION'\n" +
+            "    group by p.post_id\n" +
+            "    order by count(p2.id) DESC", nativeQuery = true
+    )
+    Page<Post> findAllOrderByParticipantByPhotoCountByCategoryDesc(@Param("categoryId") Long categoryId, Pageable pageable);
+
 }
 

--- a/src/main/java/com/matching/post/repository/PostRepositoryQuerydsl.java
+++ b/src/main/java/com/matching/post/repository/PostRepositoryQuerydsl.java
@@ -1,0 +1,9 @@
+package com.matching.post.repository;
+
+import com.matching.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryQuerydsl {
+    Page<Post> findAll(Pageable pageable, String keyword);
+}

--- a/src/main/java/com/matching/post/repository/PostRepositoryQuerydslImpl.java
+++ b/src/main/java/com/matching/post/repository/PostRepositoryQuerydslImpl.java
@@ -1,0 +1,45 @@
+package com.matching.post.repository;
+
+import com.matching.post.domain.Post;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.matching.post.domain.QPost.post;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryQuerydslImpl implements PostRepositoryQuerydsl {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<Post> findAll(Pageable pageable, String keyword) {
+        return new PageImpl<>(
+                searchPost(keyword, pageable)
+        );
+    }
+
+    private List<Post> searchPost(String keyword, Pageable pageable) {
+        return jpaQueryFactory
+                .selectFrom(post)
+                .where(
+                        eqTitle(keyword)
+                )
+                .orderBy(post.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private BooleanExpression eqTitle(String keyword) {
+        return !StringUtils.hasText(keyword) ? null : post.title.contains(keyword);
+    }
+
+}

--- a/src/main/java/com/matching/post/service/PostService.java
+++ b/src/main/java/com/matching/post/service/PostService.java
@@ -13,6 +13,7 @@ public interface PostService {
     Long writePost(PostRequest parameter, String id, List<MultipartFile> multipartFile);
     PostResponse getPost(Long id);
     Long updatePost(Long postId, Long userId, PostUpdateRequest parameter);
+    void deletePost(Long postId, Long userId);
 
     Page<PostResponse> getPostByCategoryDesc(Long categoryId);
     Long participate(PlanRequest parameter, String email, Long postId);

--- a/src/main/java/com/matching/post/service/PostService.java
+++ b/src/main/java/com/matching/post/service/PostService.java
@@ -1,13 +1,10 @@
 package com.matching.post.service;
 
 import com.matching.plan.dto.PlanRequest;
-import com.matching.post.domain.Post;
 import com.matching.post.dto.PostRequest;
 import com.matching.post.dto.PostResponse;
 import com.matching.post.dto.PostUpdateRequest;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -17,7 +14,7 @@ public interface PostService {
     PostResponse getPost(Long id);
     Long updatePost(Long postId, Long userId, PostUpdateRequest parameter);
 
-    List<PostResponse> getPostByCategoryAsc(Long categoryId);
+    Page<PostResponse> getPostByCategoryDesc(Long categoryId);
     Long participate(PlanRequest parameter, String email, Long postId);
     void completePlan(String email, Long planId);
 }

--- a/src/main/java/com/matching/post/service/PostService.java
+++ b/src/main/java/com/matching/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.matching.post.service;
 import com.matching.plan.dto.PlanRequest;
 import com.matching.post.dto.PostRequest;
 import com.matching.post.dto.PostResponse;
+import com.matching.post.dto.PostSearchRequest;
 import com.matching.post.dto.PostUpdateRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,6 +17,7 @@ public interface PostService {
     void deletePost(Long postId, Long userId);
 
     Page<PostResponse> getPostByCategoryDesc(Long categoryId);
+    Page<PostResponse> getPostSearchList(PostSearchRequest parameter);
     Long participate(PlanRequest parameter, String email, Long postId);
     void completePlan(String email, Long planId);
 }

--- a/src/main/java/com/matching/post/service/PostService.java
+++ b/src/main/java/com/matching/post/service/PostService.java
@@ -1,14 +1,14 @@
 package com.matching.post.service;
 
-import com.matching.member.domain.Member;
 import com.matching.plan.dto.PlanRequest;
-import com.matching.post.domain.PostDocument;
+import com.matching.post.domain.Post;
 import com.matching.post.dto.PostRequest;
 import com.matching.post.dto.PostResponse;
 import com.matching.post.dto.PostUpdateRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 public interface PostService {
@@ -16,6 +16,7 @@ public interface PostService {
     PostResponse getPost(Long id);
     Long updatePost(Long postId, Long userId, PostUpdateRequest parameter);
 
+    List<PostResponse> getPostByCategoryAsc(Long categoryId);
     Long participate(PlanRequest parameter, String email, Long postId);
     void completePlan(String email, Long planId);
 }

--- a/src/main/java/com/matching/post/service/PostService.java
+++ b/src/main/java/com/matching/post/service/PostService.java
@@ -6,6 +6,7 @@ import com.matching.post.dto.PostRequest;
 import com.matching.post.dto.PostResponse;
 import com.matching.post.dto.PostUpdateRequest;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
@@ -4,6 +4,8 @@ import com.matching.member.domain.Member;
 import com.matching.member.repository.MemberRepository;
 import com.matching.participate.domain.Participate;
 import com.matching.participate.repository.ParticipateRepository;
+import com.matching.photo.domain.Photo;
+import com.matching.photo.repository.PhotoRepository;
 import com.matching.photo.service.PhotoService;
 import com.matching.plan.domain.Plan;
 import com.matching.plan.dto.PlanRequest;
@@ -23,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +35,7 @@ public class PostServiceImpl implements PostService {
     private final PlanRepository planRepository;
     private final ParticipateRepository participateRepository;
     private final CategoryRepository categoryRepository;
+    private final PhotoRepository photoRepository;
 
     private final PhotoService photoService;
 
@@ -69,7 +73,12 @@ public class PostServiceImpl implements PostService {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
 
-        return PostResponse.from(post);
+        List<Photo> photoList = photoRepository.findAllByPost_Id(post.getId())
+                .orElse(null);
+        List<String> test = photoList.stream().map(item -> item.getPathname())
+                .collect(Collectors.toList());
+
+        return PostResponse.from(post, test);
     }
 
     @Transactional

--- a/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
@@ -8,11 +8,13 @@ import com.matching.photo.service.PhotoService;
 import com.matching.plan.domain.Plan;
 import com.matching.plan.dto.PlanRequest;
 import com.matching.plan.repository.PlanRepository;
+import com.matching.post.domain.Category;
 import com.matching.post.domain.Post;
 import com.matching.post.domain.PostDocument;
 import com.matching.post.dto.PostRequest;
 import com.matching.post.dto.PostResponse;
 import com.matching.post.dto.PostUpdateRequest;
+import com.matching.post.repository.CategoryRepository;
 import com.matching.post.repository.PostRepository;
 import com.matching.post.service.PostService;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,7 @@ public class PostServiceImpl implements PostService {
     private final MemberRepository memberRepository;
     private final PlanRepository planRepository;
     private final ParticipateRepository participateRepository;
+    private final CategoryRepository categoryRepository;
 
     private final PhotoService photoService;
 
@@ -38,10 +41,13 @@ public class PostServiceImpl implements PostService {
     public Long writePost(PostRequest parameter, String id, List<MultipartFile> multipartFile) {
         Member member = memberRepository.findById(Long.parseLong(id))
                         .orElseThrow(() -> new RuntimeException("회원이 없습니다."));
+        Category category = categoryRepository.findById(parameter.getCategoryId())
+                        .orElseThrow(() -> new RuntimeException("해당 카테고리가 없습니다."));
+
 
         parameter.setMember(member);
 
-        Post post = postRepository.save(Post.from(parameter));
+        Post post = postRepository.save(Post.from(parameter, category));
         Plan plan = planRepository.save(Plan.from(parameter, member, post));
 
         Participate participate = participateRepository.save(Participate.from(member, post));

--- a/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
@@ -14,9 +14,11 @@ import com.matching.post.domain.Category;
 import com.matching.post.domain.Post;
 import com.matching.post.dto.PostRequest;
 import com.matching.post.dto.PostResponse;
+import com.matching.post.dto.PostSearchRequest;
 import com.matching.post.dto.PostUpdateRequest;
 import com.matching.post.repository.CategoryRepository;
 import com.matching.post.repository.PostRepository;
+import com.matching.post.repository.PostRepositoryQuerydsl;
 import com.matching.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
@@ -37,6 +39,7 @@ public class PostServiceImpl implements PostService {
     private final ParticipateRepository participateRepository;
     private final CategoryRepository categoryRepository;
     private final PhotoRepository photoRepository;
+    private final PostRepositoryQuerydsl postRepositoryQuerydsl;
 
     private final PhotoService photoService;
 
@@ -72,6 +75,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    @Transactional
     public PostResponse getPost(Long id) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
@@ -82,6 +86,17 @@ public class PostServiceImpl implements PostService {
                 .collect(Collectors.toList());
 
         return PostResponse.from(post, test);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PostResponse> getPostSearchList(PostSearchRequest parameter) {
+        return PostResponse.fromEntitiesPage(
+                postRepositoryQuerydsl.findAll(
+                        PageRequest.of(parameter.getPageNum(), parameter.getPageSize()),
+                        parameter.getKeyword()
+                )
+        );
     }
 
     @Transactional

--- a/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
@@ -96,6 +96,23 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    public void deletePost(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 포스트가 존재하지 않습니다."));
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 정보가 없습니다."));
+
+        Participate participate = participateRepository.findByParticipate_IdAndPost_Id(member.getId(), post.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 포스트 참가자가 아닙니다."));
+
+        if(!participate.getStatus().equals(Participate.ParticipateStatus.LEADER)) {
+            throw new IllegalArgumentException("해당 포스트 리더가 아닙니다.");
+        } else {
+            postRepository.deleteById(post.getId());
+        }
+    }
+
+    @Override
     public Page<PostResponse> getPostByCategoryDesc(Long categoryId) {
         int pageNumber = 0; // 가져올 페이지 번호 (0부터 시작)
         int pageSize = 10; // 페이지당 결과 수

--- a/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
@@ -96,20 +96,20 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public List<PostResponse> getPostByCategoryAsc(Long categoryId) {
+    public Page<PostResponse> getPostByCategoryDesc(Long categoryId) {
         int pageNumber = 0; // 가져올 페이지 번호 (0부터 시작)
         int pageSize = 10; // 페이지당 결과 수
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
-
         List<PostResponse> responses = new ArrayList<>();
+
         Page<Post> postPage = postRepository.findAllOrderByParticipantByPhotoCountByCategoryDesc(categoryId, pageable);
 
-        for (Post post: postPage) {
-            List<String> photoList = post.getPhotoList().stream().map(item -> item.getPathname()).collect(Collectors.toList());
-
-            responses.add(PostResponse.from(post, photoList));
-        }
-        return responses;
+        return postPage.map(post -> {
+            List<String> photoList = post.getPhotoList().stream()
+                    .map(Photo::getPathname)
+                    .collect(Collectors.toList());
+            return PostResponse.from(post, photoList);
+        });
     }
 
     @Transactional

--- a/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/matching/post/service/impl/PostServiceImpl.java
@@ -20,10 +20,13 @@ import com.matching.post.repository.CategoryRepository;
 import com.matching.post.repository.PostRepository;
 import com.matching.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,6 +41,8 @@ public class PostServiceImpl implements PostService {
     private final PhotoRepository photoRepository;
 
     private final PhotoService photoService;
+
+
 
 
     @Transactional
@@ -90,6 +95,23 @@ public class PostServiceImpl implements PostService {
         post.update(parameter);
 
         return post.getId();
+    }
+
+    @Override
+    public List<PostResponse> getPostByCategoryAsc(Long categoryId) {
+        List<Post> postList = postRepository.findAllOrderByParticipantCountByCategoryAsc(categoryId);
+        List<PostResponse> responses = new ArrayList<>();
+
+        for (Post post: postList) {
+            List<Photo> photoList = photoRepository.findAllByPost_Id(post.getId())
+                    .orElse(null);
+            List<String> test = photoList.stream().map(item -> item.getPathname())
+                    .collect(Collectors.toList());
+
+            responses = postList.stream().map(list -> PostResponse.from(list, test )).collect(Collectors.toList());
+        }
+
+        return responses;
     }
 
     @Transactional


### PR DESCRIPTION
### jpql 쿼리 인기 게시물 조회
- native query 방식을 사용하여 직접 DB에 쿼리 조회
- 참가자 수 기준으로 정렬
<img width="794" alt="스크린샷 2023-06-02 오전 10 22 27" src="https://github.com/0jo-gil/matching_backend/assets/74961404/8a4e7f93-afeb-4436-8f7b-e18913d17c76">

---

### Querydsl 검색 기능 구현
- 추후 각 검색 조건 추가 예정 (eq~ 메소드 추가)
- Page 구현을 위해 PageImpl 구현체 커스텀
<img width="675" alt="스크린샷 2023-06-02 오전 10 25 55" src="https://github.com/0jo-gil/matching_backend/assets/74961404/c28de938-acdb-4615-b7ee-466f63ae3578">
